### PR TITLE
Update Twistlock SDK

### DIFF
--- a/sdk/credentials/credential.go
+++ b/sdk/credentials/credential.go
@@ -13,14 +13,11 @@ type ProviderCredential struct {
 	Type         string     `json:"type"`
 	AccountID    string     `json:"accountID"`
 	AccountGUID  string     `json:"accountGUID"`
+	External     bool       `json:"external"`
 	Secret       sdk.Secret `json:"secret"`
-	APIToken     APIToken   `json:"apiToken"`
+	APIToken     sdk.Secret `json:"apiToken"`
 	LastModified time.Time  `json:"lastModified"`
 	Owner        string     `json:"owner"`
-}
-
-type APIToken struct {
-	Encrypted string `json:"encrypted"`
 }
 
 func Index(c sdk.Client) ([]ProviderCredential, error) {
@@ -55,6 +52,7 @@ func Get(c sdk.Client, providerCredentialName string) (*ProviderCredential, erro
 
 func Set(c sdk.Client, spec *ProviderCredential) error {
 	req, err := c.NewRequest("POST", "credentials", spec)
+
 	if err != nil {
 		return err
 	}

--- a/sdk/policies/ci.go
+++ b/sdk/policies/ci.go
@@ -17,19 +17,19 @@ type CiResources struct {
 	Labels []string `json:"labels"`
 }
 type CiRules struct {
-	Modified       time.Time      `json:"modified"`
-	Owner          string         `json:"owner"`
-	Name           string         `json:"name"`
-	PreviousName   string         `json:"previousName"`
-	Effect         string         `json:"effect"`
-	Resources      CiResources    `json:"resources"`
-	Verbose        bool           `json:"verbose,omitempty"`
-	AlertThreshold AlertThreshold `json:"alertThreshold"`
-	BlockThreshold BlockThreshold `json:"blockThreshold"`
-	CveRules       []CveRules     `json:"cveRules,omitempty"`
-	Tags           []Tags         `json:"tags,omitempty"`
-	GraceDays      int            `json:"graceDays"`
-	OnlyFixed      bool           `json:"onlyFixed"`
+	Modified       time.Time        `json:"modified"`
+	Owner          string           `json:"owner"`
+	Name           string           `json:"name"`
+	PreviousName   string           `json:"previousName"`
+	Effect         string           `json:"effect"`
+	Collections    []sdk.Collection `json:"collections"`
+	Verbose        bool             `json:"verbose,omitempty"`
+	AlertThreshold AlertThreshold   `json:"alertThreshold"`
+	BlockThreshold BlockThreshold   `json:"blockThreshold"`
+	CveRules       []CveRules       `json:"cveRules,omitempty"`
+	Tags           []Tags           `json:"tags,omitempty"`
+	GraceDays      int              `json:"graceDays"`
+	OnlyFixed      bool             `json:"onlyFixed"`
 }
 
 func GetCi(c sdk.Client) (*Ci, error) {

--- a/sdk/policies/images.go
+++ b/sdk/policies/images.go
@@ -12,31 +12,21 @@ type Images struct {
 	PolicyType string       `json:"policyType"`
 	ID         string       `json:"_id"`
 }
-type ImageResources struct {
-	Hosts      []string `json:"hosts"`
-	Images     []string `json:"images"`
-	Labels     []string `json:"labels"`
-	Containers []string `json:"containers"`
-	Namespaces []string `json:"namespaces"`
-	AccountIDs []string `json:"accountIDs"`
-	Clusters   []string `json:"clusters"`
-}
-
 type ImageRules struct {
-	Modified       time.Time      `json:"modified"`
-	Owner          string         `json:"owner"`
-	Name           string         `json:"name"`
-	PreviousName   string         `json:"previousName"`
-	Effect         string         `json:"effect"`
-	Resources      ImageResources `json:"resources"`
-	BlockMsg       string         `json:"blockMsg,omitempty"`
-	Verbose        bool           `json:"verbose,omitempty"`
-	AlertThreshold AlertThreshold `json:"alertThreshold"`
-	BlockThreshold BlockThreshold `json:"blockThreshold"`
-	CveRules       []CveRules     `json:"cveRules,omitempty"`
-	Tags           []Tags         `json:"tags,omitempty"`
-	GraceDays      int            `json:"graceDays"`
-	OnlyFixed      bool           `json:"onlyFixed"`
+	Modified       time.Time        `json:"modified"`
+	Owner          string           `json:"owner"`
+	Name           string           `json:"name"`
+	PreviousName   string           `json:"previousName"`
+	Effect         string           `json:"effect"`
+	Collections    []sdk.Collection `json:"collections"`
+	BlockMsg       string           `json:"blockMsg,omitempty"`
+	Verbose        bool             `json:"verbose,omitempty"`
+	AlertThreshold AlertThreshold   `json:"alertThreshold"`
+	BlockThreshold BlockThreshold   `json:"blockThreshold"`
+	CveRules       []CveRules       `json:"cveRules,omitempty"`
+	Tags           []Tags           `json:"tags,omitempty"`
+	GraceDays      int              `json:"graceDays"`
+	OnlyFixed      bool             `json:"onlyFixed"`
 }
 
 func GetImages(c sdk.Client) (*Images, error) {

--- a/sdk/policies/runtime.go
+++ b/sdk/policies/runtime.go
@@ -11,14 +11,7 @@ type Runtime struct {
 	Rules            []RuntimeRules `json:"rules"`
 	LearningDisabled bool           `json:"learningDisabled"`
 }
-type RuntimeResources struct {
-	Hosts      []string `json:"hosts"`
-	Images     []string `json:"images"`
-	Labels     []string `json:"labels"`
-	Containers []string `json:"containers"`
-	Namespaces []string `json:"namespaces"`
-	AccountIDs []string `json:"accountIDs"`
-}
+
 type Processes struct {
 	Effect               string   `json:"effect"`
 	Blacklist            []string `json:"blacklist"`
@@ -68,7 +61,7 @@ type RuntimeRules struct {
 	Name                     string           `json:"name"`
 	Notes                    string           `json:"notes"`
 	PreviousName             string           `json:"previousName"`
-	Resources                RuntimeResources `json:"resources"`
+	Collections              []sdk.Collection `json:"collections"`
 	AdvancedProtection       bool             `json:"advancedProtection"`
 	Processes                Processes        `json:"processes"`
 	Network                  Network          `json:"network"`

--- a/sdk/shared.go
+++ b/sdk/shared.go
@@ -1,6 +1,27 @@
 package sdk
 
+import "time"
+
 type Secret struct {
 	Encrypted string `json:"encrypted"`
 	Plain     string `json:"plain"`
+}
+
+type Collection struct {
+	Hosts       []string  `json:"hosts"`
+	Images      []string  `json:"images"`
+	Labels      []string  `json:"labels"`
+	Containers  []string  `json:"containers"`
+	Functions   []string  `json:"functions"`
+	Namespaces  []string  `json:"namespaces"`
+	AppIDs      []string  `json:"appIDs"`
+	AccountIDs  []string  `json:"accountIDs"`
+	CodeRepos   []string  `json:"codeRepos"`
+	Clusters    []string  `json:"clusters"`
+	Name        string    `json:"name"`
+	Owner       string    `json:"owner"`
+	Modified    time.Time `json:"modified"`
+	Color       string    `json:"color"`
+	Description string    `json:"description"`
+	System      bool      `json:"system"`
 }

--- a/sdk/subnets/subnet.go
+++ b/sdk/subnets/subnet.go
@@ -44,7 +44,7 @@ func Get(c sdk.Client, subnetName string) (*Subnet, error) {
 }
 
 func Update(c sdk.Client, subnet *Subnet) error {
-	req, err := c.NewRequest("PUT", fmt.Sprintf("policies/firewall/app/network-list/%s", subnet.ID), subnet)
+	req, err := c.NewRequest("PUT", "policies/firewall/app/network-list", subnet)
 	if err != nil {
 		return err
 	}

--- a/sdk/waas/waas.go
+++ b/sdk/waas/waas.go
@@ -12,24 +12,7 @@ type Waas struct {
 	MinPort int    `json:"minPort"`
 	MaxPort int    `json:"maxPort"`
 }
-type Collection struct {
-	Hosts       []string  `json:"hosts"`
-	Images      []string  `json:"images"`
-	Labels      []string  `json:"labels"`
-	Containers  []string  `json:"containers"`
-	Functions   []string  `json:"functions"`
-	Namespaces  []string  `json:"namespaces"`
-	AppIDs      []string  `json:"appIDs"`
-	AccountIDs  []string  `json:"accountIDs"`
-	CodeRepos   []string  `json:"codeRepos"`
-	Clusters    []string  `json:"clusters"`
-	Name        string    `json:"name"`
-	Owner       string    `json:"owner"`
-	Modified    time.Time `json:"modified"`
-	Color       string    `json:"color"`
-	Description string    `json:"description"`
-	System      bool      `json:"system"`
-}
+
 type Certificate struct {
 	Encrypted string `json:"encrypted"`
 }
@@ -179,7 +162,7 @@ type Rule struct {
 	Owner            string            `json:"owner"`
 	Name             string            `json:"name"`
 	PreviousName     string            `json:"previousName"`
-	Collections      []Collection      `json:"collections"`
+	Collections      []sdk.Collection  `json:"collections"`
 	ApplicationsSpec []ApplicationSpec `json:"applicationsSpec"`
 	ExpandDetails    bool              `json:"expandDetails"`
 }

--- a/twistlock/resource_collection.go
+++ b/twistlock/resource_collection.go
@@ -78,6 +78,7 @@ func resourceCollection() *schema.Resource {
 				},
 			},
 			"name": {
+				ForceNew:    true,
 				Required:    true,
 				Type:        schema.TypeString,
 				Description: "Name of the collection",

--- a/twistlock/resource_vulnerability_policies.go
+++ b/twistlock/resource_vulnerability_policies.go
@@ -6,7 +6,6 @@ import (
 	"github.com/Hivebrite/twistlock-go/sdk"
 	"github.com/Hivebrite/twistlock-go/sdk/policies"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/spf13/cast"
 )
 
 func resourceImagePolicies() *schema.Resource {
@@ -46,7 +45,7 @@ func resourceImagePolicies() *schema.Resource {
 							Type:        schema.TypeBool,
 							Description: "",
 						},
-						"resources": policiesResourcesSchema([]string{"hosts", "images", "labels", "containers", "namespaces", "account_ids", "clusters"}),
+						"collections": collectionSchema(),
 						"block_msg": {
 							Computed:    true,
 							Optional:    true,
@@ -85,22 +84,13 @@ func parseImagePolicies(d *schema.ResourceData) *policies.Images {
 
 	for _, i := range rules {
 		rule := i.(map[string]interface{})
-		resources := rule["resources"].(*schema.Set).List()[0].(map[string]interface{})
 		tags := rule["tags"].(*schema.Set).List()
 		cveRules := rule["cve_rules"].(*schema.Set).List()
 
 		ruleObject := policies.ImageRules{
-			Name:      rule["name"].(string),
-			OnlyFixed: rule["only_fixed"].(bool),
-			Resources: policies.ImageResources{
-				Hosts:      cast.ToStringSlice(resources["hosts"]),
-				Images:     cast.ToStringSlice(resources["images"]),
-				Labels:     cast.ToStringSlice(resources["labels"]),
-				Containers: cast.ToStringSlice(resources["containers"]),
-				Namespaces: cast.ToStringSlice(resources["namespaces"]),
-				AccountIDs: cast.ToStringSlice(resources["account_ids"]),
-				Clusters:   cast.ToStringSlice(resources["clusters"]),
-			},
+			Name:           rule["name"].(string),
+			OnlyFixed:      rule["only_fixed"].(bool),
+			Collections:    parseCollections(rule["collections"].(*schema.Set).List()),
 			BlockMsg:       rule["block_msg"].(string),
 			Verbose:        rule["verbose"].(bool),
 			AlertThreshold: *alertThresholdFromRule(rule),
@@ -182,23 +172,12 @@ func saveImagePolicies(d *schema.ResourceData, policiesObject *policies.Images) 
 		rules = append(
 			rules,
 			map[string]interface{}{
-				"name":       i.Name,
-				"only_fixed": i.OnlyFixed,
-
-				"resources": []map[string]interface{}{
-					{
-						"hosts":       i.Resources.Hosts,
-						"images":      i.Resources.Images,
-						"labels":      i.Resources.Labels,
-						"containers":  i.Resources.Containers,
-						"namespaces":  i.Resources.Namespaces,
-						"account_ids": i.Resources.AccountIDs,
-						"clusters":    i.Resources.Clusters,
-					},
-				},
-				"block_msg": i.BlockMsg,
-				"verbose":   i.Verbose,
-				"effect":    i.Effect,
+				"name":        i.Name,
+				"only_fixed":  i.OnlyFixed,
+				"collections": collectionSliceToInterface(i.Collections),
+				"block_msg":   i.BlockMsg,
+				"verbose":     i.Verbose,
+				"effect":      i.Effect,
 				"alert_threshold": []map[string]interface{}{
 					{
 						"disabled": i.AlertThreshold.Disabled,

--- a/twistlock/resource_waas_container.go
+++ b/twistlock/resource_waas_container.go
@@ -1095,7 +1095,10 @@ func saveWaasContainer(d *schema.ResourceData, waasObject *waas.Waas) error {
 				},
 				"bot_protection_spec": []map[string]interface{}{
 					{
-						"user_defined_bots": userDefinedBots,
+						"user_defined_bots":  userDefinedBots,
+						"session_validation": botProtectionSpec.SessionValidation,
+						"interstitial_page":  botProtectionSpec.InterstitialPage,
+
 						"known_bot_protections_spec": []map[string]interface{}{
 							{
 								"search_engine_crawlers": knownBotProtectionsSpec.SearchEngineCrawlers,

--- a/twistlock/resource_waas_container.go
+++ b/twistlock/resource_waas_container.go
@@ -129,7 +129,7 @@ func resourceWaasContainer() *schema.Resource {
 													Elem: &schema.Resource{
 														Schema: map[string]*schema.Schema{
 															"methods": {
-																Required:    true,
+																Optional:    true,
 																Type:        schema.TypeList,
 																Description: "",
 																Elem: &schema.Schema{
@@ -146,7 +146,7 @@ func resourceWaasContainer() *schema.Resource {
 															},
 															"response_code_ranges": {
 																Type:        schema.TypeList,
-																Required:    true,
+																Optional:    true,
 																Description: "",
 																Elem: &schema.Resource{
 																	Schema: map[string]*schema.Schema{
@@ -911,19 +911,32 @@ func parseWaasContainer(d *schema.ResourceData) *waas.Waas {
 			var dosConditions []waas.MatchConditions
 
 			if len(dosConfig["match_conditions"].([]interface{})) > 0 {
-				for _, matchConditions := range dosConfig["match_conditions"].([]map[string]interface{}) {
+				for _, matchConditionsInterface := range dosConfig["match_conditions"].([]interface{}) {
+					matchConditions := matchConditionsInterface.(map[string]interface{})
 					var responseCodeRanges []waas.ResponseCodeRange
-					for _, codeRange := range matchConditions["response_code_ranges"].([]map[string]interface{}) {
+					for _, codeRangeInterface := range matchConditions["response_code_ranges"].([]interface{}) {
+						codeRange := codeRangeInterface.(map[string]interface{})
 						responseCodeRanges = append(responseCodeRanges,
 							waas.ResponseCodeRange{
 								Start: codeRange["start"].(int),
 								End:   codeRange["end"].(int),
 							})
 					}
+
+					var methods []string
+					for _, method := range matchConditions["methods"].([]interface{}) {
+						methods = append(methods, method.(string))
+					}
+
+					var fileTypes []string
+					for _, fileType := range matchConditions["file_types"].([]interface{}) {
+						fileTypes = append(fileTypes, fileType.(string))
+					}
+
 					dosConditions = append(dosConditions,
 						waas.MatchConditions{
-							Methods:            matchConditions["mmatchConditionsethods"].([]string),
-							FileTypes:          matchConditions["FileTypematchConditions"].([]string),
+							Methods:            methods,
+							FileTypes:          fileTypes,
 							ResponseCodeRanges: responseCodeRanges,
 						})
 				}

--- a/twistlock/resource_waas_container.go
+++ b/twistlock/resource_waas_container.go
@@ -54,81 +54,8 @@ func resourceWaasContainer() *schema.Resource {
 							Type:        schema.TypeString,
 							Description: "",
 						},
-						"collections": {
-							Type:        schema.TypeSet,
-							Required:    true,
-							Description: "",
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"hosts": {
-										Computed:    true,
-										Type:        schema.TypeList,
-										Description: "",
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
-									},
-									"images": {
-										Computed:    true,
-										Type:        schema.TypeList,
-										Description: "",
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
-									},
-									"labels": {
-										Computed:    true,
-										Type:        schema.TypeList,
-										Description: "",
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
-									},
-									"containers": {
-										Computed:    true,
-										Type:        schema.TypeList,
-										Description: "",
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
-									},
-									"namespaces": {
-										Computed:    true,
-										Type:        schema.TypeList,
-										Description: "",
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
-									},
-									"account_ids": {
-										Computed:    true,
-										Type:        schema.TypeList,
-										Description: "",
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
-									},
-									"clusters": {
-										Computed:    true,
-										Type:        schema.TypeList,
-										Description: "",
-										Elem: &schema.Schema{
-											Type: schema.TypeString,
-										},
-									},
-									"name": {
-										Required:    true,
-										Type:        schema.TypeString,
-										Description: "Name of the collection",
-									},
-									"description": {
-										Computed:    true,
-										Type:        schema.TypeString,
-										Description: "",
-									},
-								},
-							},
-						},
+						"collections": collectionSchema(),
+
 						"applications_spec": {
 							Required:    true,
 							Type:        schema.TypeList,
@@ -875,17 +802,7 @@ func parseWaasContainer(d *schema.ResourceData) *waas.Waas {
 			Name: rule["name"].(string),
 		}
 
-		var collectionsList []waas.Collection
-
-		for _, collection := range rule["collections"].(*schema.Set).List() {
-			c := collection.(map[string]interface{})
-			collectionsList = append(collectionsList,
-				waas.Collection{
-					Name: c["name"].(string),
-				})
-		}
-
-		ruleObject.Collections = collectionsList
+		ruleObject.Collections = parseCollections(rule["collections"].(*schema.Set).List())
 
 		for _, j := range applicationsSpec {
 			applicationSpec := j.(map[string]interface{})
@@ -1269,15 +1186,7 @@ func saveWaasContainer(d *schema.ResourceData, waasObject *waas.Waas) error {
 			})
 		}
 
-		var collections []map[string]interface{}
-
-		for _, collection := range i.Collections {
-			collections = append(collections,
-				map[string]interface{}{
-					"name": collection.Name,
-				},
-			)
-		}
+		collections := collectionSliceToInterface(i.Collections)
 
 		waasRules = append(
 			waasRules,

--- a/twistlock/schema.go
+++ b/twistlock/schema.go
@@ -198,31 +198,81 @@ func policiesAlertThresholdSchema() *schema.Schema {
 	}
 }
 
-func policiesResourcesSchema(keys []string) *schema.Schema {
-	ruleSchema := map[string]*schema.Schema{}
-
-	for _, i := range keys {
-		ruleSchema[i] = &schema.Schema{
-			Required:    true,
-			Type:        schema.TypeList,
-			Description: "",
-			Elem: &schema.Schema{
-				Type: schema.TypeString,
-			},
-		}
-	}
-
-	var model = &schema.Resource{
-		Schema: ruleSchema,
-	}
-
+func collectionSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeSet,
 		Required:    true,
 		Description: "",
-		MinItems:    1,
-		MaxItems:    1,
-		Elem:        model,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"hosts": {
+					Computed:    true,
+					Type:        schema.TypeList,
+					Description: "",
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+				"images": {
+					Computed:    true,
+					Type:        schema.TypeList,
+					Description: "",
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+				"labels": {
+					Computed:    true,
+					Type:        schema.TypeList,
+					Description: "",
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+				"containers": {
+					Computed:    true,
+					Type:        schema.TypeList,
+					Description: "",
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+				"namespaces": {
+					Computed:    true,
+					Type:        schema.TypeList,
+					Description: "",
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+				"account_ids": {
+					Computed:    true,
+					Type:        schema.TypeList,
+					Description: "",
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+				"clusters": {
+					Computed:    true,
+					Type:        schema.TypeList,
+					Description: "",
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+				"name": {
+					Required:    true,
+					Type:        schema.TypeString,
+					Description: "Name of the collection",
+				},
+				"description": {
+					Computed:    true,
+					Type:        schema.TypeString,
+					Description: "",
+				},
+			},
+		},
 	}
 }
 

--- a/twistlock/shared_policies.go
+++ b/twistlock/shared_policies.go
@@ -3,6 +3,7 @@ package twistlock
 import (
 	"time"
 
+	"github.com/Hivebrite/twistlock-go/sdk"
 	"github.com/Hivebrite/twistlock-go/sdk/policies"
 )
 
@@ -88,4 +89,32 @@ func expirationMapFromObject(expiration policies.Expiration) *map[string]interfa
 		schema["date"] = timeToString(expiration.Date)
 	}
 	return &schema
+}
+
+func parseCollections(collectionsList []interface{}) []sdk.Collection {
+	var collectionsSlice []sdk.Collection
+
+	for _, collection := range collectionsList {
+		c := collection.(map[string]interface{})
+		collectionsSlice = append(collectionsSlice,
+			sdk.Collection{
+				Name: c["name"].(string),
+			})
+	}
+
+	return collectionsSlice
+}
+
+func collectionSliceToInterface(collectionsSlice []sdk.Collection) []map[string]interface{} {
+	var collections []map[string]interface{}
+
+	for _, collection := range collectionsSlice {
+		collections = append(collections,
+			map[string]interface{}{
+				"name": collection.Name,
+			},
+		)
+	}
+
+	return collections
 }


### PR DESCRIPTION
- Generalize use of collections instead of resources
- minor changes to the credential resource (allow to use PrismaCloud token instead of passing GCP keys)
- minor changes to the WAF resource (do not trigger changes when there are none)