### PR TITLE
Improve the exception fields support for WaaS

### DIFF
--- a/twistlock/resource_waas_container.go
+++ b/twistlock/resource_waas_container.go
@@ -1507,6 +1507,7 @@ func applicationSpecEffectsSchema() *schema.Schema {
 							Description: "",
 							ValidateFunc: validation.StringInSlice(
 								[]string{
+									"path",
 									"query",
 									"body",
 									"cookie",

--- a/twistlock/resource_waas_container.go
+++ b/twistlock/resource_waas_container.go
@@ -1443,7 +1443,7 @@ func applicationSpecEffectsFromInterface(applicationSpecEffects map[string]inter
 			field := exceptionField.(map[string]interface{})
 			exceptionFields = append(exceptionFields,
 				waas.ExceptionFields{
-					Location: field["effect"].(string),
+					Location: field["location"].(string),
 					Key:      field["key"].(string),
 				})
 		}


### PR DESCRIPTION
This PR aims to :
- fix a bug when assigning exception fields to a WaaS rule
- add a support for the "location" param with value "path".

it allows to add path exception for WaaS rules.